### PR TITLE
Async Additions and Auto Starting

### DIFF
--- a/angular-promise-queue.js
+++ b/angular-promise-queue.js
@@ -1,5 +1,5 @@
 angular.module('promise-queue', [])
-  .factory('PromiseQueue', function($q) {
+  .factory('PromiseQueue', ['$q', function($q) {
 
     var PromiseQueue = function (autoStart){
       this.autoStart = autoStart || false;
@@ -15,7 +15,7 @@ angular.module('promise-queue', [])
      * @returns {undefined}
      */
     PromiseQueue.prototype.add = function(func, instant) {
-      var instant = instant || false;
+      instant = instant || false;
 
       if(Array.isArray(func)) {
         this._queue = this._queue.concat(func);
@@ -152,4 +152,4 @@ angular.module('promise-queue', [])
     return PromiseQueue;
 
 
-  });
+}]);

--- a/angular-promise-queue.js
+++ b/angular-promise-queue.js
@@ -1,10 +1,12 @@
 angular.module('promise-queue', [])
-  .factory('PromiseQueue', ['$q', function($q) {
+  .factory('PromiseQueue', function($q) {
 
-    var PromiseQueue = function (){
+    var PromiseQueue = function (autoStart){
+      this.autoStart = autoStart || false;
       this._queue = [];
       this._pause = false;
-    };
+      this._head = false;
+    }
 
     /**
      * Adds a function to the queue. It optionally accepts an array of functions
@@ -13,7 +15,7 @@ angular.module('promise-queue', [])
      * @returns {undefined}
      */
     PromiseQueue.prototype.add = function(func, instant) {
-      instant = instant || false;
+      var instant = instant || false;
 
       if(Array.isArray(func)) {
         this._queue = this._queue.concat(func);
@@ -27,6 +29,10 @@ angular.module('promise-queue', [])
 
       }else{
         throw new Error('No functions provided');
+      }
+
+      if(this.autoStart && !this._pause){
+        this.next();
       }
 
       return this;
@@ -116,13 +122,17 @@ angular.module('promise-queue', [])
 
       if(self._pause === true) return;
       if(self._queue.length === 0) return;
+      if(self._head === true) return;
 
       var func = self._queue.shift();
 
+      self._head = true;
+
       promisify(func)
         .then(function() {
+          self._head = false;
           self.next();
-        });
+        })
 
     };
 
@@ -142,4 +152,4 @@ angular.module('promise-queue', [])
     return PromiseQueue;
 
 
-  }]);
+  });

--- a/ionic/www/js/angular-promise-queue.js
+++ b/ionic/www/js/angular-promise-queue.js
@@ -1,5 +1,5 @@
 angular.module('promise-queue', [])
-  .factory('PromiseQueue', function($q) {
+  .factory('PromiseQueue', ['$q', function($q) {
 
     var PromiseQueue = function (autoStart){
       this.autoStart = autoStart || false;
@@ -15,7 +15,7 @@ angular.module('promise-queue', [])
      * @returns {undefined}
      */
     PromiseQueue.prototype.add = function(func, instant) {
-      var instant = instant || false;
+      instant = instant || false;
 
       if(Array.isArray(func)) {
         this._queue = this._queue.concat(func);
@@ -152,4 +152,4 @@ angular.module('promise-queue', [])
     return PromiseQueue;
 
 
-  });
+}]);

--- a/ionic/www/js/angular-promise-queue.js
+++ b/ionic/www/js/angular-promise-queue.js
@@ -1,9 +1,11 @@
 angular.module('promise-queue', [])
   .factory('PromiseQueue', function($q) {
 
-    var PromiseQueue = function (){
+    var PromiseQueue = function (autoStart){
+      this.autoStart = autoStart || false;
       this._queue = [];
       this._pause = false;
+      this._head = false;
     }
 
     /**
@@ -27,6 +29,10 @@ angular.module('promise-queue', [])
 
       }else{
         throw new Error('No functions provided');
+      }
+
+      if(this.autoStart && !this._pause){
+        this.next();
       }
 
       return this;
@@ -116,11 +122,15 @@ angular.module('promise-queue', [])
 
       if(self._pause === true) return;
       if(self._queue.length === 0) return;
+      if(self._head === true) return;
 
       var func = self._queue.shift();
 
+      self._head = true;
+
       promisify(func)
         .then(function() {
+          self._head = false;
           self.next();
         })
 

--- a/ionic/www/js/app.js
+++ b/ionic/www/js/app.js
@@ -1,6 +1,6 @@
 angular.module('starter', ['ionic', 'promise-queue'])
 
-  .directive('wordSlide', function(PromiseQueue) {
+  .directive('wordSlide', function(PromiseQueue, $timeout) {
 
     return {
       restrict: 'E',
@@ -10,7 +10,9 @@ angular.module('starter', ['ionic', 'promise-queue'])
 
         var elements = $element.children();
 
-        var promiseQueue = new PromiseQueue();
+        var useAutoStart = true;
+        
+        var promiseQueue = new PromiseQueue(useAutoStart);
 
         var slideIn = function(el){
           return function(done) {
@@ -20,19 +22,23 @@ angular.module('starter', ['ionic', 'promise-queue'])
           }
         }
 
-        promiseQueue
-          .add(slideIn(elements[0]))
-          .add(slideIn(elements[1]))
-          .add(slideIn(elements[2]))
-          .add(slideIn(elements[3]))
-          .add(slideIn(elements[4]))
-          .add(slideIn(elements[5]))
-          .add(slideIn(elements[6]))
-          .add(slideIn(elements[7]));
 
           var startButton = document.getElementById('start');
           angular.element(startButton).on('click', function() {
-            promiseQueue.start();
+
+              promiseQueue
+                .add(slideIn(elements[0]))
+                .add(slideIn(elements[1]))
+                .add(slideIn(elements[2]))
+                .add(slideIn(elements[3]));
+
+              $timeout(function(){
+                  promiseQueue
+                    .add(slideIn(elements[4]))
+                    .add(slideIn(elements[5]))
+                    .add(slideIn(elements[6]))
+                    .add(slideIn(elements[7]));
+              }, 25);
           });
 
           function whichTransitionEvent(){


### PR DESCRIPTION
Just food for thought, I tested the current implementation against an async $timeout call and split the additions in half - one set outside the timeout and one inside. Instead of the queue being dealt with sequentially like expected, both halves ended up showing at the same time in the ionic demo of the project.

Adding a _head flag to make sure the queue doesn't already have an active head fixed this issue.

Also, I thought it would be helpful to have an option for the queue to auto-start when add is called so items could be dealt with as they come in.
